### PR TITLE
Feat/template form front

### DIFF
--- a/backend/api-client/environments/tier-master.bru
+++ b/backend/api-client/environments/tier-master.bru
@@ -1,3 +1,3 @@
 vars {
-  host: http://localhost:3000
+  host: http://localhost:3000/api
 }

--- a/backend/api-client/get tierlist.bru
+++ b/backend/api-client/get tierlist.bru
@@ -1,0 +1,11 @@
+meta {
+  name: get tierlist
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{host}}/tierlist/1
+  body: none
+  auth: inherit
+}

--- a/backend/api-client/ping.bru
+++ b/backend/api-client/ping.bru
@@ -1,0 +1,11 @@
+meta {
+  name: ping
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{host}}
+  body: none
+  auth: inherit
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.15",
+        "lucide-vue-next": "^0.503.0",
         "pinia": "^3.0.1",
         "tailwindcss": "^4.0.15",
         "vue": "^3.5.13",
@@ -5088,6 +5089,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lucide-vue-next": {
+      "version": "0.503.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.503.0.tgz",
+      "integrity": "sha512-3MrtHIBdh4dPCUZDLxQnvmQ17UzUnBYgezUSIo87Laais8hOz6qIPllp0iG/uS/UIzk7bJxyZRzoZTW/gLSr4A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -6237,6 +6247,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -6485,14 +6537,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
+      "integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.3",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.12"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -6664,6 +6719,32 @@
       },
       "peerDependencies": {
         "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest": {

--- a/front/package.json
+++ b/front/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.15",
+    "lucide-vue-next": "^0.503.0",
     "pinia": "^3.0.1",
     "tailwindcss": "^4.0.15",
     "vue": "^3.5.13",

--- a/front/src/assets/main.css
+++ b/front/src/assets/main.css
@@ -11,6 +11,8 @@
   --color-dark-green-custom: #1D7874;
   --color-black-custom: #0C0C0C;
   --color-white-custom: #F7F7F8;
+  --font-roboto: "Roboto Mono", monospace;
+  --font-jersey: "Jersey 25", sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/front/src/assets/main.css
+++ b/front/src/assets/main.css
@@ -1,8 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Jersey+25&family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=swap');
 @import "tailwindcss";
+
 
 @theme {
   --color-red-custom: #DB504A;
   --color-gray-custom: #2F2D2E;
+  --color-dark-gray-custom: #1A1C1E;
+  --color-light-gray-custom: #88898B;
   --color-light-green-custom: #31E7C3;
   --color-dark-green-custom: #1D7874;
   --color-black-custom: #0C0C0C;
@@ -12,9 +16,14 @@
 @media (prefers-color-scheme: dark) {
   :root {
     color-scheme: dark;
+    font-family: "Roboto Mono", monospace;
+    font-optical-sizing: auto;
+    font-weight: 400;
+    font-size: 16px;
+    font-style: normal;
   }
 }
 #app {
-  @apply bg-gray-custom
+  @apply bg-dark-gray-custom
   min-h-screen
 }

--- a/front/src/presentation/components/ItemCard.vue
+++ b/front/src/presentation/components/ItemCard.vue
@@ -47,17 +47,13 @@ const onDragEnd = () => {
 };
 
 const toggleNameBubble = () => {
-  // Only show bubble if not currently dragging
   if (props.isDragging) return;
 
   showNameBubble.value = true;
-
-  // Clear any existing timeout
   if (timeoutId.value !== null) {
     window.clearTimeout(timeoutId.value);
   }
 
-  // Auto-hide the bubble after 2 seconds
   timeoutId.value = window.setTimeout(() => {
     showNameBubble.value = false;
   }, 2000);

--- a/front/src/presentation/components/base/BaseInput.vue
+++ b/front/src/presentation/components/base/BaseInput.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const model = defineModel<string>()
+</script>
+
+<template>
+  <input
+    v-bind="$attrs"
+    v-model="model"
+    class="rounded-lg px-4 py-2 bg-white-custom text-dark-gray-custom outline-none text-base"
+  />
+</template>

--- a/front/src/presentation/components/base/Button.vue
+++ b/front/src/presentation/components/base/Button.vue
@@ -7,18 +7,19 @@ type Size = 'sm' | 'md' | 'lg'
 type ButtonType = 'button' | 'submit' | 'reset'
 type IconName = 'plus' | 'image-up' | 'rows-3' | ''
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   type?: ButtonType
   size?: Size
   icon?: IconName
   variant?: 'primary' | 'secondary' | 'danger'
-}>()
+}>(), {
+  type: 'button',
+  size: 'md',
+  variant: 'primary',
+  icon: '',
+})
 
-const variant = props.variant ?? 'primary'
-const type = props.type ?? 'button'
-const size = props.size ?? 'md'
-
-// Mapping icônes
+// Icon mapping
 const iconMap: Record<IconName, any> = {
   'plus': Plus,
   'image-up': ImageUp,
@@ -26,23 +27,28 @@ const iconMap: Record<IconName, any> = {
   '': null,
 }
 
-const IconComponent = computed(() => iconMap[props.icon ?? ''])
+// Using computed for icons
+const IconComponent = computed(() => iconMap[props.icon])
+
+// Explicit definition of events
+const emit = defineEmits(['click'])
 </script>
 
 <template>
   <button
     :type="type"
     :class="[
-      'inline-flex text-white-custom cursor-pointer items-center gap-2 rounded-lg px-4 py-2 border-b-2 border-r-2 active:border-none transition',
+      'flex text-white-custom cursor-pointer items-center gap-2 rounded-lg px-4 py-2 border-b-2 border-r-2 active:border-none transition',
       {
         'text-sm py-1 px-3': size === 'sm',
         'text-base py-2 px-4': size === 'md',
         'text-xl py-3 px-5': size === 'lg',
         'bg-dark-green-custom border-light-green-custom': variant === 'primary',
-        'bg-light-gray-custom border-dark-green-custom ': variant === 'secondary',
-        'bg-red-custom border-white-custom' : variant === 'danger',
+        'bg-light-gray-custom border-dark-green-custom': variant === 'secondary',
+        'bg-red-custom border-white-custom': variant === 'danger',
       }
     ]"
+    @click="$emit('click')"
   >
     <component v-if="IconComponent" :is="IconComponent" class="w-5 h-5" />
     <slot />

--- a/front/src/presentation/components/base/Button.vue
+++ b/front/src/presentation/components/base/Button.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Plus, ImageUp, Rows3 } from 'lucide-vue-next'
+
+// Props types
+type Size = 'sm' | 'md' | 'lg'
+type ButtonType = 'button' | 'submit' | 'reset'
+type IconName = 'plus' | 'image-up' | 'rows-3' | ''
+
+const props = defineProps<{
+  type?: ButtonType
+  size?: Size
+  icon?: IconName
+  variant?: 'primary' | 'secondary' | 'danger'
+}>()
+
+const variant = props.variant ?? 'primary'
+const type = props.type ?? 'button'
+const size = props.size ?? 'md'
+
+// Mapping icônes
+const iconMap: Record<IconName, any> = {
+  'plus': Plus,
+  'image-up': ImageUp,
+  'rows-3': Rows3,
+  '': null,
+}
+
+const IconComponent = computed(() => iconMap[props.icon ?? ''])
+</script>
+
+<template>
+  <button
+    :type="type"
+    :class="[
+      'inline-flex text-white-custom cursor-pointer items-center gap-2 rounded-lg px-4 py-2 border-b-2 border-r-2 active:border-none transition',
+      {
+        'text-sm py-1 px-3': size === 'sm',
+        'text-base py-2 px-4': size === 'md',
+        'text-xl py-3 px-5': size === 'lg',
+        'bg-dark-green-custom border-light-green-custom': variant === 'primary',
+        'bg-light-gray-custom border-dark-green-custom ': variant === 'secondary',
+        'bg-red-custom border-white-custom' : variant === 'danger',
+      }
+    ]"
+  >
+    <component v-if="IconComponent" :is="IconComponent" class="w-5 h-5" />
+    <slot />
+  </button>
+</template>

--- a/front/src/presentation/components/base/ImagePreviewInput.vue
+++ b/front/src/presentation/components/base/ImagePreviewInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { CircleMinus, Image } from 'lucide-vue-next'
-import { ref, defineExpose } from 'vue'
+import { ref } from 'vue'
 import BaseInput from './BaseInput.vue'
 
 const file = ref<File | null>(null)

--- a/front/src/presentation/components/base/ImagePreviewInput.vue.vue
+++ b/front/src/presentation/components/base/ImagePreviewInput.vue.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { CircleMinus, Image } from 'lucide-vue-next'
+import { ref, defineExpose } from 'vue'
+import BaseInput from './BaseInput.vue'
+
+const file = ref<File | null>(null)
+const imageName = ref('')
+const previewUrl = ref<string | null>(null)
+
+const onFileChange = (e: Event) => {
+  const target = e.target as HTMLInputElement
+  if (target.files && target.files[0]) {
+    file.value = target.files[0]
+    previewUrl.value = URL.createObjectURL(target.files[0])
+  }
+}
+
+const removeImage = () => {
+  file.value = null
+  imageName.value = ''
+  previewUrl.value = null
+}
+
+// Function to get image data
+const getImageData = () => {
+  if (file.value && previewUrl.value && imageName.value) {
+    return {
+      name: imageName.value,
+      url: previewUrl.value,
+    }
+  }
+  return null
+}
+
+defineExpose({ file, imageName, previewUrl, getImageData, removeImage })
+</script>
+
+<template>
+  <div class="relative flex flex-col border-2 border-white-custom rounded-xl w-[300px]">
+    <label class="cursor-pointer relative z-10 w-[300px] h-[200px] flex items-center justify-center">
+      <Image :size="32" class="bg-gray-custom/30 rounded-md backdrop-blur-3xl" />
+      <input
+        type="file"
+        accept="image/*"
+        @change="onFileChange"
+        class="hidden"
+      />
+    </label>
+    <button v-if="file" @click="removeImage()" class="top-1 right-1 absolute z-10 bg-red-custom rounded-full cursor-pointer">
+        <CircleMinus />
+    </button>
+    <BaseInput
+      type="text"
+      v-model="imageName"
+      placeholder="Image name"
+      class="rounded-t-none h-[96px] text-lg"
+    />
+    <div v-if="previewUrl" class="absolute rounded-t-[10px] overflow-hidden w-[296px] h-[200px]">
+      <img :src="previewUrl" alt="Preview" class="h-full w-full object-cover" />
+    </div>
+  </div>
+</template>

--- a/front/src/presentation/router/index.ts
+++ b/front/src/presentation/router/index.ts
@@ -9,14 +9,11 @@ const router = createRouter({
       name: 'TierList',
       component: TierListView,
     },
-    // {
-    //   path: '/about',
-    //   name: 'about',
-    //   // route level code-splitting
-    //   // this generates a separate chunk (About.[hash].js) for this route
-    //   // which is lazy-loaded when the route is visited.
-    //   component: () => import('../views/AboutView.vue'),
-    // },
+    {
+      path: '/create-template',
+      name: 'create-template',
+      component: () => import('../views/TemplateCreationView.vue'),
+    },
   ],
 })
 

--- a/front/src/presentation/views/TemplateCreationView.vue
+++ b/front/src/presentation/views/TemplateCreationView.vue
@@ -1,12 +1,59 @@
 <script setup lang="ts">
 import Button from '../components/base/Button.vue';
+import BaseInput from '../components/base/BaseInput.vue';
+import { ref } from 'vue';
+const templateName = ref<string>('');
+const templateCategories = ref<string[]>([]);
+const currentCategory = ref<string>('');
+
+const addCategory = () => {
+  if (currentCategory.value.trim() !== '') {
+    templateCategories.value.push(currentCategory.value.trim());
+    currentCategory.value = '';
+  }
+};
 
 
 </script>
 
 <template>
-  <main>
-    <Button variant="primary" type="button" size="md" icon="plus" class="mb-4">
+  <main class="m-16">
+    <label for="templateName">
+      <h1 class="text-[40px] font-jersey">Tierlist Title</h1>
+    </label>
+    <BaseInput
+      id="templateName"
+      type="text"
+      placeholder="My Tierlist title ..."
+      class="mb-4 w-1/3 max-w-2xl"
+      v-model="templateName"
+    />
+    <label for="category">
+      <h2 class="text-2xl font-jersey">Add #categories</h2>
+    </label>
+    <BaseInput
+      id="category"
+      type="text"
+      placeholder="category ..."
+      class="mb-4 max-w-sm"
+      v-model="currentCategory"
+    />
+    <Button
+      variant="primary"
+      type="button"
+      size="md"
+      icon="plus"
+      class="ml-4 inline-flex"
+      @click="addCategory"
+    >
+      Add Category
+  </Button>
+    <ul class="flex gap-2">
+      <li v-for="(category, index) in templateCategories" :key="index">
+        <span class="text-xl font-jersey bg-gray-custom rounded-full px-2 py-2">{{ category }}</span>
+      </li>
+    </ul>
+    <Button variant="primary" type="button" size="md" icon="plus" class="mt-4">
       Create Template
     </Button>
   </main>

--- a/front/src/presentation/views/TemplateCreationView.vue
+++ b/front/src/presentation/views/TemplateCreationView.vue
@@ -5,6 +5,8 @@ import { ref } from 'vue';
 const templateName = ref<string>('');
 const templateCategories = ref<string[]>([]);
 const currentCategory = ref<string>('');
+import { CircleMinus } from 'lucide-vue-next';
+import ImagePreviewInput from '../components/base/ImagePreviewInput.vue.vue';
 
 const addCategory = () => {
   if (currentCategory.value.trim() !== '') {
@@ -13,48 +15,149 @@ const addCategory = () => {
   }
 };
 
+const removeCategory = (index: number) => {
+  templateCategories.value.splice(index, 1);
+};
 
+const imageUploadRef = ref()
+
+const previewImages = ref<{ name: string; url: string }[]>([])
+const showNameBubbles = ref<boolean[]>([])
+
+const triggerAddToPreview = () => {
+  const refValue = imageUploadRef.value
+  if (refValue && refValue.getImageData) {
+    const imageData = refValue.getImageData()
+    if (imageData) {
+      previewImages.value.push(imageData)
+      showNameBubbles.value.push(false) //add a state for the new image
+      refValue.removeImage()
+    }
+  }
+}
+
+// show bubble with image name
+const showNameBubble = (idx: number) => {
+  showNameBubbles.value[idx] = true
+  setTimeout(() => {
+    showNameBubbles.value[idx] = false
+  }, 2000)
+}
+
+const removePreviewImage = (index: number) => {
+  previewImages.value.splice(index, 1)
+  showNameBubbles.value.splice(index, 1)
+}
 </script>
 
 <template>
-  <main class="m-16">
+  <main class="p-16">
     <label for="templateName">
       <h1 class="text-[40px] font-jersey">Tierlist Title</h1>
     </label>
-    <BaseInput
-      id="templateName"
-      type="text"
-      placeholder="My Tierlist title ..."
-      class="mb-4 w-1/3 max-w-2xl"
-      v-model="templateName"
-    />
+    <BaseInput id="templateName" type="text" placeholder="My Tierlist title ..." class="mb-4 w-1/3 max-w-2xl"
+      v-model="templateName" />
     <label for="category">
       <h2 class="text-2xl font-jersey">Add #categories</h2>
     </label>
-    <BaseInput
-      id="category"
-      type="text"
-      placeholder="category ..."
-      class="mb-4 max-w-sm"
-      v-model="currentCategory"
-    />
-    <Button
-      variant="primary"
-      type="button"
-      size="md"
-      icon="plus"
-      class="ml-4 inline-flex"
-      @click="addCategory"
-    >
-      Add Category
-  </Button>
-    <ul class="flex gap-2">
-      <li v-for="(category, index) in templateCategories" :key="index">
-        <span class="text-xl font-jersey bg-gray-custom rounded-full px-2 py-2">{{ category }}</span>
+    <form class="flex gap-2" @submit.prevent="addCategory">
+      <BaseInput id="category" type="text" placeholder="category ..." class="mb-4 max-w-sm block"
+        v-model="currentCategory" />
+      <Button variant="secondary" type="submit" size="md" icon="plus" class="mb-4">
+      </Button>
+    </form>
+    <ul class="flex flex-wrap pb-4 max-w-xl gap-4">
+      <li v-for="(category, index) in templateCategories" :key="index" class="relative">
+        <span class="bg-gray-custom rounded-full px-4 py-2 font-normal text-base font-roboto">{{ category }}</span>
+        <button @click="removeCategory(index)"
+          class="absolute w-6 h-6 rounded-full bg-light-gray-custom -top-2 -right-3 z-1 flex cursor-pointer">
+          <CircleMinus />
+        </button>
       </li>
     </ul>
-    <Button variant="primary" type="button" size="md" icon="plus" class="mt-4">
-      Create Template
-    </Button>
+    <div class="sm:flex-col flex md:flex-row gap-16">
+      <div>
+        <ImagePreviewInput ref="imageUploadRef" />
+        <Button variant="primary" type="button" size="md" icon="image-up" @click="triggerAddToPreview" class="mt-4">
+          Add to the tierlist
+        </Button>
+      </div>
+      <div>
+        <div v-if="previewImages.length > 0" class="flex flex-wrap border-2 rounded-xl p-4 gap-4 max-w-5xl">
+          <div
+            v-for="(img, idx) in previewImages"
+            :key="idx"
+            class="flex flex-col items-center relative"
+            @click="showNameBubble(idx)"
+            style="cursor: pointer;"
+          >
+            <img :src="img.url" :alt="img.name" class="w-19 h-19 object-cover rounded-md" />
+            <button
+              @click.stop="removePreviewImage(idx)"
+              class="absolute w-6 h-6 rounded-full bg-light-gray-custom -top-2 -right-3 z-10 flex items-center justify-center cursor-pointer"
+              style="border: none;"
+              aria-label="Remove image"
+            >
+              <CircleMinus />
+            </button>
+            <div v-if="showNameBubbles[idx]" class="name-bubble">
+              {{ img.name }}
+            </div>
+          </div>
+        </div>
+        <div v-else>
+          No images added yet.
+        </div>
+      </div>
+    </div>
+    <div class="flex pt-16">
+      <Button variant="secondary" type="button" size="lg" class="mt-4">
+        Save Template
+      </Button>
+      <Button variant="primary" type="button" size="lg" class="mt-4 ml-4">
+        Publish Template
+      </Button>
+    </div>
   </main>
 </template>
+
+<style scoped>
+.name-bubble {
+  position: absolute;
+  top: -40px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  z-index: 20;
+  animation: fadeIn 0.2s ease-out;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.name-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 5px 5px 0;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.8) transparent transparent;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 5px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+</style>

--- a/front/src/presentation/views/TemplateCreationView.vue
+++ b/front/src/presentation/views/TemplateCreationView.vue
@@ -6,7 +6,7 @@ const templateName = ref<string>('');
 const templateCategories = ref<string[]>([]);
 const currentCategory = ref<string>('');
 import { CircleMinus } from 'lucide-vue-next';
-import ImagePreviewInput from '../components/base/ImagePreviewInput.vue.vue';
+import ImagePreviewInput from '../components/base/ImagePreviewInput.vue';
 
 const addCategory = () => {
   if (currentCategory.value.trim() !== '') {

--- a/front/src/presentation/views/TemplateCreationView.vue
+++ b/front/src/presentation/views/TemplateCreationView.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import Button from '../components/base/Button.vue';
+
+
+</script>
+
+<template>
+  <main>
+    <Button variant="primary" type="button" size="md" icon="plus" class="mb-4">
+      Create Template
+    </Button>
+  </main>
+</template>

--- a/front/src/presentation/views/TemplateCreationView.vue
+++ b/front/src/presentation/views/TemplateCreationView.vue
@@ -87,15 +87,13 @@ const removePreviewImage = (index: number) => {
           <div
             v-for="(img, idx) in previewImages"
             :key="idx"
-            class="flex flex-col items-center relative"
+            class="flex flex-col items-center relative cursor-pointer"
             @click="showNameBubble(idx)"
-            style="cursor: pointer;"
           >
             <img :src="img.url" :alt="img.name" class="w-19 h-19 object-cover rounded-md" />
             <button
               @click.stop="removePreviewImage(idx)"
-              class="absolute w-6 h-6 rounded-full bg-light-gray-custom -top-2 -right-3 z-10 flex items-center justify-center cursor-pointer"
-              style="border: none;"
+              class="absolute w-6 h-6 rounded-full bg-light-gray-custom -top-2 -right-3 z-10 flex items-center justify-center cursor-pointer border-none"
               aria-label="Remove image"
             >
               <CircleMinus />


### PR DESCRIPTION
This pull request introduces several updates across the backend and frontend, including API adjustments, dependency updates, and new features for the frontend application. The most significant changes involve creating new API endpoints, enhancing the frontend's UI components, and adding functionality for template creation. Below is a categorized summary of the most important changes:

### Backend Updates:
* Updated the `host` variable in `tier-master.bru` to include `/api` in the base URL for consistency across API requests.
* Added two new API endpoints:
  * `get tierlist` endpoint for retrieving tier list data.
  * `ping` endpoint for health checks.

### Frontend Dependency Updates:
* Added `lucide-vue-next` as a dependency for using icons in Vue components. [[1]](diffhunk://#diff-6f9eb7ef83f901b54ce82bbb05850f61dcb9707cec9d5bf912f99d820b569a25R12) [[2]](diffhunk://#diff-ca702b44edbd4e2dacdcc476120b86b9c80adddef71a6ca381a85184175a5df3R18)
* Updated `vite` to version `6.3.2` and added `tinyglobby` for improved build performance and file matching. [[1]](diffhunk://#diff-6f9eb7ef83f901b54ce82bbb05850f61dcb9707cec9d5bf912f99d820b569a25L6488-R6550) [[2]](diffhunk://#diff-6f9eb7ef83f901b54ce82bbb05850f61dcb9707cec9d5bf912f99d820b569a25R6250-R6291)

### Frontend Styling and Assets:
* Imported Google Fonts (`Roboto Mono` and `Jersey 25`) and added custom font variables in `main.css`. Updated the app's background color and font styling for dark mode.

### New Frontend Components:
* Added `BaseInput.vue` for reusable input fields with consistent styling.
* Created a `Button.vue` component with support for sizes, variants, and icons using `lucide-vue-next`.
* Introduced `ImagePreviewInput.vue` for uploading, previewing, and managing images.

### Template Creation Feature:
* Added a new `TemplateCreationView.vue` that allows users to create templates with tier list titles, categories, and image previews. Includes functionality for managing categories and previewing images with name bubbles.
* Updated the router to include a new route for the template creation view (`/create-template`).